### PR TITLE
Convert giraph to standalone and refactor the tests

### DIFF
--- a/bigtop-packages/src/charm/giraph/layer-giraph/README.md
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/README.md
@@ -35,10 +35,10 @@ hadoop-processing`.
 
 This will deploy an Apache Bigtop Hadoop cluster. More information about this deployment can be found in the [bundle readme](https://jujucharms.com/hadoop-processing/).
 
-Now add Giraph and relate it to the cluster endpoint:
+Now add Giraph and relate it to the cluster:
 
     juju deploy giraph
-    juju add-relation giraph client
+    juju add-relation giraph plugin
 
 ## Network-Restricted Environments
 
@@ -92,7 +92,7 @@ of Juju, the syntax is `juju action fetch <action-id>`.
 
 # Resources
 
-- [Apache Bigtop home page](http://bigtop.apache.org/) 
+- [Apache Bigtop home page](http://bigtop.apache.org/)
 - [Apache Bigtop mailing lists](http://bigtop.apache.org/mail-lists.html)
 - [Apache Giraph home page](http://giraph.apache.org/)
 - [Apache Giraph issue tracker](https://issues.apache.org/jira/browse/GIRAPH)

--- a/bigtop-packages/src/charm/giraph/layer-giraph/actions/smoke-test
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/actions/smoke-test
@@ -17,18 +17,55 @@
 
 set -ex
 
-if hdfs dfs -stat /tmp/input/ &> /dev/null; then
-    hdfs dfs -rm -r -skipTrash /tmp/input/ || true
+if ! charms.reactive is_state 'giraph.installed'; then
+    action-fail 'Giraph is not yet ready'
+    exit
 fi
 
-hdfs dfs -mkdir /tmp/input/
-hdfs dfs -put resources/tiny_graph.txt /tmp/input/
+# create dir to store results
+RUN=`date +%s`
+RESULT_DIR=/opt/giraph-smoke-results
+RESULT_LOG=${RESULT_DIR}/${RUN}.log
+mkdir -p ${RESULT_DIR}
+chown -R ubuntu:ubuntu ${RESULT_DIR}
 
-if hdfs dfs -stat temp &> /dev/null; then
-    hdfs dfs -rm -r -skipTrash temp || true
-fi
-if hdfs dfs -stat output &> /dev/null; then
-    hdfs dfs -rm -r -skipTrash output || true
-fi
+# hdfs dirs
+GIRAPH_SMOKE="/tmp/giraph-smoke"
+GIRAPH_INPUT="${GIRAPH_SMOKE}/input"
+GIRAPH_OUTPUT="${GIRAPH_SMOKE}/output"
 
-hadoop jar /usr/lib/giraph/giraph-core.jar org.apache.giraph.GiraphRunner -libjars ${LIB_JARS} org.apache.giraph.examples.SimplePageRankComputation -vif org.apache.giraph.io.formats.JsonLongDoubleFloatDoubleVertexInputFormat -vip /tmp/input/tiny_graph.txt -mc org.apache.giraph.examples.SimplePageRankComputation\$SimplePageRankMasterCompute -vof org.apache.giraph.io.formats.IdWithValueTextOutputFormat -op output -w 1 -ca mapred.job.tracker=empty yarn.log-aggregation-enable=true
+# remove any previous smoke test run. must be run as ubuntu, since that user
+# owns the hdfs space
+su - ubuntu -c "hadoop fs -rm -f -r -skipTrash ${GIRAPH_SMOKE}"
+
+echo 'running giraph smoke-test as the ubuntu user'
+# NB: Escaped envars in the block below (e.g., \${LIB_JARS}) come from
+# the environment while non-escaped vars (e.g., ${GIRAPH_INPUT}) come from
+# this outer scope.
+su ubuntu << EOF
+set -x
+. /etc/default/hadoop
+. /etc/environment
+
+# setup our smoke test input
+hdfs dfs -mkdir -p ${GIRAPH_INPUT}
+hdfs dfs -put \${CHARM_DIR}/resources/tiny_graph.txt ${GIRAPH_INPUT}
+
+hadoop jar /usr/lib/giraph/giraph-core.jar \
+  org.apache.giraph.GiraphRunner \
+  -libjars \${LIB_JARS} \
+  org.apache.giraph.examples.SimplePageRankComputation \
+  -vif org.apache.giraph.io.formats.JsonLongDoubleFloatDoubleVertexInputFormat \
+  -vip ${GIRAPH_INPUT}/tiny_graph.txt \
+  -mc org.apache.giraph.examples.SimplePageRankComputation\\\$SimplePageRankMasterCompute \
+  -vof org.apache.giraph.io.formats.IdWithValueTextOutputFormat \
+  -op ${GIRAPH_OUTPUT} \
+  -w 1 \
+  -ca mapred.job.tracker=empty \
+  yarn.log-aggregation-enable=true 2>&1 | tee -a ${RESULT_LOG}
+EOF
+echo 'giraph smoke-test complete'
+
+# Set action output
+RAW=`cat ${RESULT_LOG}`
+action-set raw="${RAW}"

--- a/bigtop-packages/src/charm/giraph/layer-giraph/layer.yaml
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/layer.yaml
@@ -1,6 +1,4 @@
 repo: https://github.com/panagiotisl/bigtop/tree/master/bigtop-packages/src/charm/giraph/layer-giraph
 includes:
   - 'layer:apache-bigtop-base'
-options:
-  basic:
-    use_venv: true
+  - 'layer:hadoop-client'

--- a/bigtop-packages/src/charm/giraph/layer-giraph/metadata.yaml
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/metadata.yaml
@@ -1,11 +1,8 @@
 name: giraph
 summary: Large-scale graph processing on Hadoop
 maintainer: Panagiotis Liakos <p.liakos@di.uoa.gr>
-description: The Apache Giraph project's goal is to provide an environment that addresses the challenges of Managing Big Graphs.
-tags: [graph processing]
-subordinate: true
+description: |
+  The Apache Giraph project's goal is to provide an environment that addresses
+  the challenges of Managing Big Graphs.
+tags: ['graph processing']
 series: ['xenial']
-requires:
-  mahout:
-    interface: mahout
-    scope: container

--- a/bigtop-packages/src/charm/giraph/layer-giraph/reactive/giraph.py
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/reactive/giraph.py
@@ -13,15 +13,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from jujubigdata import utils
-from charms.reactive import when, when_not, set_state
-from charms.layer.apache_bigtop_base import Bigtop
+from path import Path
+
+from charms.reactive import is_state, when, when_not, set_state
+from charms.layer.apache_bigtop_base import Bigtop, get_package_version
 from charmhelpers.core import hookenv
 
 
+def get_good_jars(dir, prefix=True):
+    """
+    Walk a directory (non-recursively) and return a list of (good) jars.
+
+    Some jars included in giraph have classes that are incompatible with yarn
+    nodemanagers. Filter these out when constructing a list of good
+    jars. If omitting the entire .jar is too coarse, the jar will need to be
+    reconstructed with the offending .class removed.
+
+    param: str dir: Directory to walk
+    param: bool prefix: When true, prepend the directory to each jar entry
+    """
+    # Known incompatible jars:
+    # - hive-exec-0.11.0 protobuf class
+    #   java.lang.VerifyError: ... overrides final method getUnknownFields
+    bad_jars = ['hive-exec-0.11.0.jar']
+    good_jars = []
+    for file in os.listdir(dir):
+        if file.endswith('.jar') and file not in bad_jars:
+            good_jars.append(Path(dir / file) if prefix else file)
+
+    return good_jars
+
+
 @when('bigtop.available')
+def report_status():
+    """Set juju status based on the deployment topology."""
+    hadoop_joined = is_state('hadoop.joined')
+    hadoop_ready = is_state('hadoop.ready')
+    giraph_installed = is_state('giraph.installed')
+    if not hadoop_joined:
+        hookenv.status_set('blocked',
+                           'waiting for relation to hadoop plugin')
+    elif not hadoop_ready:
+        hookenv.status_set('waiting',
+                           'waiting for hadoop')
+    elif giraph_installed:
+        hookenv.status_set('active',
+                           'ready')
+
+
+@when('bigtop.available', 'hadoop.ready')
 @when_not('giraph.installed')
-def install_giraph():
+def install_giraph(hadoop):
+    """Install giraph when prerequisite states are present."""
     hookenv.status_set('maintenance', 'installing giraph')
     bigtop = Bigtop()
     bigtop.render_site_yaml(
@@ -30,11 +76,29 @@ def install_giraph():
         ],
     )
     bigtop.trigger_puppet()
+    giraph_home = Path('/usr/lib/giraph')
+    giraph_libdir = Path(giraph_home / 'lib')
+    giraph_examples = Path('{}/resources/giraph-examples-1.1.0.jar'.format(
+        hookenv.charm_dir()))
+
+    # Gather a list of all the giraph jars (needed for -libjars)
+    giraph_jars = [giraph_examples]
+    giraph_jars.extend(get_good_jars(giraph_home, prefix=True))
+    giraph_jars.extend(get_good_jars(giraph_libdir, prefix=True))
+
+    # Update environment with appropriate giraph bits. HADOOP_CLASSPATH can
+    # use wildcards (and it should for readability), but LIB_JARS needs to be
+    # a comma-separate list of jars.
     with utils.environment_edit_in_place('/etc/environment') as env:
-        env['GIRAPH_HOME'] = '/usr/lib/giraph'
-        env['HADOOP_CLASSPATH'] = '/usr/lib/giraph/giraph-accumulo-1.1.0.jar:/usr/lib/giraph/giraph-core.jar:/usr/lib/giraph/giraph-hbase-1.1.0.jar:/usr/lib/giraph/giraph-hcatalog.jar:/usr/lib/giraph/giraph-kibble-1.1.0.jar:/usr/lib/giraph/giraph-rexster.jar:/usr/lib/giraph/giraph-accumulo.jar:/usr/lib/giraph/giraph-gora-1.1.0.jar:/usr/lib/giraph/giraph-hbase.jar:/usr/lib/giraph/giraph-hive-1.1.0.jar:/usr/lib/giraph/giraph-kibble.jar:/usr/lib/giraph/giraph-core-1.1.0.jar:/usr/lib/giraph/giraph-gora.jar:/usr/lib/giraph/giraph-hcatalog-1.1.0.jar:/usr/lib/giraph/giraph-hive.jar:/usr/lib/giraph/giraph-rexster-io-1.1.0.jar:resources/giraph-examples-1.1.0.jar:/usr/lib/giraph/lib/JavaEWAH-0.3.2.jar:/usr/lib/giraph/lib/cxf-api-2.5.2.jar:/usr/lib/giraph/lib/jackson-jaxrs-1.9.13.jar:/usr/lib/giraph/lib/rexster-core-2.4.0.jar:/usr/lib/giraph/lib/ST4-4.0.4.jar:/usr/lib/giraph/lib/cxf-common-utilities-2.5.2.jar:/usr/lib/giraph/lib/jackson-mapper-asl-1.9.2.jar:/usr/lib/giraph/lib/servlet-api-2.5-20081211.jar:/usr/lib/giraph/lib/activation-1.1.jar:/usr/lib/giraph/lib/cxf-rt-bindings-xml-2.5.2.jar:/usr/lib/giraph/lib/jackson-xc-1.9.13.jar:/usr/lib/giraph/lib/sigar-1.6.5.132-5.jar:/usr/lib/giraph/lib/annotations-2.0.2.jar:/usr/lib/giraph/lib/cxf-rt-core-2.5.2.jar:/usr/lib/giraph/lib/javax.inject-1.jar:/usr/lib/giraph/lib/slf4j-api-1.7.5.jar:/usr/lib/giraph/lib/antlr-2.7.7.jar:/usr/lib/giraph/lib/cxf-rt-frontend-jaxrs-2.5.2.jar:/usr/lib/giraph/lib/javolution-5.5.1.jar:/usr/lib/giraph/lib/slf4j-log4j12-1.7.5.jar:/usr/lib/giraph/lib/antlr-3.4.jar:/usr/lib/giraph/lib/cxf-rt-transports-common-2.5.2.jar:/usr/lib/giraph/lib/jaxb-api-2.2.2.jar:/usr/lib/giraph/lib/slice-0.5.jar:/usr/lib/giraph/lib/antlr-runtime-3.4.jar:/usr/lib/giraph/lib/cxf-rt-transports-http-2.5.2.jar:/usr/lib/giraph/lib/jaxb-impl-2.2.4-1.jar:/usr/lib/giraph/lib/snappy-java-1.0.5.jar:/usr/lib/giraph/lib/aopalliance-1.0.jar:/usr/lib/giraph/lib/datanucleus-connectionpool-2.0.3.jar:/usr/lib/giraph/lib/jdo2-api-2.3-ec.jar:/usr/lib/giraph/lib/spring-aop-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/asm-4.0.jar:/usr/lib/giraph/lib/datanucleus-core-2.0.3.jar:/usr/lib/giraph/lib/jersey-core-1.17.jar:/usr/lib/giraph/lib/spring-asm-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/avro-1.7.6.jar:/usr/lib/giraph/lib/datanucleus-rdbms-2.0.3.jar:/usr/lib/giraph/lib/jersey-json-1.17.jar:/usr/lib/giraph/lib/spring-beans-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/avro-ipc-1.7.6-tests.jar:/usr/lib/giraph/lib/derby-10.4.2.0.jar:/usr/lib/giraph/lib/jettison-1.3.3.jar:/usr/lib/giraph/lib/spring-context-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/avro-ipc-1.7.6.jar:/usr/lib/giraph/lib/fastutil-6.5.4.jar:/usr/lib/giraph/lib/jetty-6.1.26.jar:/usr/lib/giraph/lib/spring-core-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/avro-mapred-1.7.6.jar:/usr/lib/giraph/lib/geronimo-javamail_1.4_spec-1.7.1.jar:/usr/lib/giraph/lib/jetty-util-6.1.26.jar:/usr/lib/giraph/lib/spring-expression-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/base64-2.3.8.jar:/usr/lib/giraph/lib/giraph-core-1.1.0-tests.jar:/usr/lib/giraph/lib/jline-0.9.94.jar:/usr/lib/giraph/lib/spring-web-3.0.6.RELEASE.jar:/usr/lib/giraph/lib/blueprints-core-2.4.0.jar:/usr/lib/giraph/lib/gora-core-0.5.jar:/usr/lib/giraph/lib/jmxutils-1.16.jar:/usr/lib/giraph/lib/stats-0.91.jar:/usr/lib/giraph/lib/bval-core-0.5.jar:/usr/lib/giraph/lib/guava-14.0.1.jar:/usr/lib/giraph/lib/jol-core-0.1.jar:/usr/lib/giraph/lib/stax-api-1.0.1.jar:/usr/lib/giraph/lib/bval-jsr303-0.5.jar:/usr/lib/giraph/lib/guice-3.0.jar:/usr/lib/giraph/lib/json-20090211.jar:/usr/lib/giraph/lib/stax2-api-3.1.1.jar:/usr/lib/giraph/lib/cglib-nodep-2.2.2.jar:/usr/lib/giraph/lib/guice-multibindings-3.0.jar:/usr/lib/giraph/lib/jsr311-api-1.1.1.jar:/usr/lib/giraph/lib/stringtemplate-3.2.1.jar:/usr/lib/giraph/lib/colt-1.2.0.jar:/usr/lib/giraph/lib/hcatalog-core-0.5.0-incubating.jar:/usr/lib/giraph/lib/jta-1.1.jar:/usr/lib/giraph/lib/swift-annotations-0.13.1.jar:/usr/lib/giraph/lib/commons-beanutils-1.7.0.jar:/usr/lib/giraph/lib/hive-builtins-0.10.0.jar:/usr/lib/giraph/lib/jython-2.5.3.jar:/usr/lib/giraph/lib/swift-codec-0.13.1.jar:/usr/lib/giraph/lib/commons-beanutils-core-1.8.0.jar:/usr/lib/giraph/lib/hive-cli-0.10.0.jar:/usr/lib/giraph/lib/libfb303-0.9.0.jar:/usr/lib/giraph/lib/swift-service-0.13.1.jar:/usr/lib/giraph/lib/commons-cli-1.2.jar:/usr/lib/giraph/lib/hive-exec-0.11.0.jar:/usr/lib/giraph/lib/libthrift-0.9.0.jar:/usr/lib/giraph/lib/typetools-0.2.1.jar:/usr/lib/giraph/lib/commons-codec-1.8.jar:/usr/lib/giraph/lib/hive-io-exp-core-0.26.jar:/usr/lib/giraph/lib/log4j-1.2.17.jar:/usr/lib/giraph/lib/units-0.91.jar:/usr/lib/giraph/lib/commons-compress-1.4.1.jar:/usr/lib/giraph/lib/hive-metastore-0.11.0.jar:/usr/lib/giraph/lib/metrics-core-2.2.0.jar:/usr/lib/giraph/lib/validation-api-1.1.0.Final.jar:/usr/lib/giraph/lib/commons-configuration-1.6.jar:/usr/lib/giraph/lib/hive-pdk-0.10.0.jar:/usr/lib/giraph/lib/metrics-core-3.0.0.jar:/usr/lib/giraph/lib/velocity-1.7.jar:/usr/lib/giraph/lib/commons-dbcp-1.4.jar:/usr/lib/giraph/lib/hive-service-0.10.0.jar:/usr/lib/giraph/lib/neethi-3.0.1.jar:/usr/lib/giraph/lib/woodstox-core-asl-4.1.1.jar:/usr/lib/giraph/lib/commons-digester-1.8.jar:/usr/lib/giraph/lib/httpclient-4.1.2.jar:/usr/lib/giraph/lib/netty-3.6.2.Final.jar:/usr/lib/giraph/lib/wsdl4j-1.6.2.jar:/usr/lib/giraph/lib/commons-io-2.1.jar:/usr/lib/giraph/lib/httpcore-4.1.2.jar:/usr/lib/giraph/lib/netty-all-4.0.14.Final.jar:/usr/lib/giraph/lib/xmlschema-core-2.0.1.jar:/usr/lib/giraph/lib/commons-lang-2.6.jar:/usr/lib/giraph/lib/jackson-annotations-2.1.4.jar:/usr/lib/giraph/lib/nifty-client-0.13.1.jar:/usr/lib/giraph/lib/xz-1.0.jar:/usr/lib/giraph/lib/commons-lang3-3.1.jar:/usr/lib/giraph/lib/jackson-core-2.1.2.jar:/usr/lib/giraph/lib/nifty-core-0.13.1.jar:/usr/lib/giraph/lib/yjp-controller-api-redist-11.0.10.jar:/usr/lib/giraph/lib/commons-pool-1.5.4.jar:/usr/lib/giraph/lib/jackson-core-asl-1.9.2.jar:/usr/lib/giraph/lib/paranamer-2.5.2.jar:/usr/lib/giraph/lib/zookeeper-3.4.5.jar:/usr/lib/giraph/lib/concurrent-1.3.4.jar:/usr/lib/giraph/lib/jackson-databind-2.1.2.jar:/usr/lib/giraph/lib/protobuf-java-2.5.0.jar:/usr/lib/giraph/lib/configuration-0.91.jar:/usr/lib/giraph/lib/jackson-datatype-json-org-2.1.2.jar:/usr/lib/giraph/lib/reflectasm-1.07.jar:resources/giraph-examples-1.1.0.jar'
-        env['LIB_JARS'] = '/usr/lib/giraph/giraph-accumulo-1.1.0.jar,/usr/lib/giraph/giraph-core.jar,/usr/lib/giraph/giraph-hbase-1.1.0.jar,/usr/lib/giraph/giraph-hcatalog.jar,/usr/lib/giraph/giraph-kibble-1.1.0.jar,/usr/lib/giraph/giraph-rexster.jar,/usr/lib/giraph/giraph-accumulo.jar,/usr/lib/giraph/giraph-gora-1.1.0.jar,/usr/lib/giraph/giraph-hbase.jar,/usr/lib/giraph/giraph-hive-1.1.0.jar,/usr/lib/giraph/giraph-kibble.jar,/usr/lib/giraph/giraph-core-1.1.0.jar,/usr/lib/giraph/giraph-gora.jar,/usr/lib/giraph/giraph-hcatalog-1.1.0.jar,/usr/lib/giraph/giraph-hive.jar,/usr/lib/giraph/giraph-rexster-io-1.1.0.jar,resources/giraph-examples-1.1.0.jar,/usr/lib/giraph/lib/JavaEWAH-0.3.2.jar,/usr/lib/giraph/lib/cxf-api-2.5.2.jar,/usr/lib/giraph/lib/jackson-jaxrs-1.9.13.jar,/usr/lib/giraph/lib/rexster-core-2.4.0.jar,/usr/lib/giraph/lib/ST4-4.0.4.jar,/usr/lib/giraph/lib/cxf-common-utilities-2.5.2.jar,/usr/lib/giraph/lib/jackson-mapper-asl-1.9.2.jar,/usr/lib/giraph/lib/servlet-api-2.5-20081211.jar,/usr/lib/giraph/lib/activation-1.1.jar,/usr/lib/giraph/lib/cxf-rt-bindings-xml-2.5.2.jar,/usr/lib/giraph/lib/jackson-xc-1.9.13.jar,/usr/lib/giraph/lib/sigar-1.6.5.132-5.jar,/usr/lib/giraph/lib/annotations-2.0.2.jar,/usr/lib/giraph/lib/cxf-rt-core-2.5.2.jar,/usr/lib/giraph/lib/javax.inject-1.jar,/usr/lib/giraph/lib/slf4j-api-1.7.5.jar,/usr/lib/giraph/lib/antlr-2.7.7.jar,/usr/lib/giraph/lib/cxf-rt-frontend-jaxrs-2.5.2.jar,/usr/lib/giraph/lib/javolution-5.5.1.jar,/usr/lib/giraph/lib/slf4j-log4j12-1.7.5.jar,/usr/lib/giraph/lib/antlr-3.4.jar,/usr/lib/giraph/lib/cxf-rt-transports-common-2.5.2.jar,/usr/lib/giraph/lib/jaxb-api-2.2.2.jar,/usr/lib/giraph/lib/slice-0.5.jar,/usr/lib/giraph/lib/antlr-runtime-3.4.jar,/usr/lib/giraph/lib/cxf-rt-transports-http-2.5.2.jar,/usr/lib/giraph/lib/jaxb-impl-2.2.4-1.jar,/usr/lib/giraph/lib/snappy-java-1.0.5.jar,/usr/lib/giraph/lib/aopalliance-1.0.jar,/usr/lib/giraph/lib/datanucleus-connectionpool-2.0.3.jar,/usr/lib/giraph/lib/jdo2-api-2.3-ec.jar,/usr/lib/giraph/lib/spring-aop-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/asm-4.0.jar,/usr/lib/giraph/lib/datanucleus-core-2.0.3.jar,/usr/lib/giraph/lib/jersey-core-1.17.jar,/usr/lib/giraph/lib/spring-asm-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/avro-1.7.6.jar,/usr/lib/giraph/lib/datanucleus-rdbms-2.0.3.jar,/usr/lib/giraph/lib/jersey-json-1.17.jar,/usr/lib/giraph/lib/spring-beans-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/avro-ipc-1.7.6-tests.jar,/usr/lib/giraph/lib/derby-10.4.2.0.jar,/usr/lib/giraph/lib/jettison-1.3.3.jar,/usr/lib/giraph/lib/spring-context-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/avro-ipc-1.7.6.jar,/usr/lib/giraph/lib/fastutil-6.5.4.jar,/usr/lib/giraph/lib/jetty-6.1.26.jar,/usr/lib/giraph/lib/spring-core-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/avro-mapred-1.7.6.jar,/usr/lib/giraph/lib/geronimo-javamail_1.4_spec-1.7.1.jar,/usr/lib/giraph/lib/jetty-util-6.1.26.jar,/usr/lib/giraph/lib/spring-expression-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/base64-2.3.8.jar,/usr/lib/giraph/lib/giraph-core-1.1.0-tests.jar,/usr/lib/giraph/lib/jline-0.9.94.jar,/usr/lib/giraph/lib/spring-web-3.0.6.RELEASE.jar,/usr/lib/giraph/lib/blueprints-core-2.4.0.jar,/usr/lib/giraph/lib/gora-core-0.5.jar,/usr/lib/giraph/lib/jmxutils-1.16.jar,/usr/lib/giraph/lib/stats-0.91.jar,/usr/lib/giraph/lib/bval-core-0.5.jar,/usr/lib/giraph/lib/guava-14.0.1.jar,/usr/lib/giraph/lib/jol-core-0.1.jar,/usr/lib/giraph/lib/stax-api-1.0.1.jar,/usr/lib/giraph/lib/bval-jsr303-0.5.jar,/usr/lib/giraph/lib/guice-3.0.jar,/usr/lib/giraph/lib/json-20090211.jar,/usr/lib/giraph/lib/stax2-api-3.1.1.jar,/usr/lib/giraph/lib/cglib-nodep-2.2.2.jar,/usr/lib/giraph/lib/guice-multibindings-3.0.jar,/usr/lib/giraph/lib/jsr311-api-1.1.1.jar,/usr/lib/giraph/lib/stringtemplate-3.2.1.jar,/usr/lib/giraph/lib/colt-1.2.0.jar,/usr/lib/giraph/lib/hcatalog-core-0.5.0-incubating.jar,/usr/lib/giraph/lib/jta-1.1.jar,/usr/lib/giraph/lib/swift-annotations-0.13.1.jar,/usr/lib/giraph/lib/commons-beanutils-1.7.0.jar,/usr/lib/giraph/lib/hive-builtins-0.10.0.jar,/usr/lib/giraph/lib/jython-2.5.3.jar,/usr/lib/giraph/lib/swift-codec-0.13.1.jar,/usr/lib/giraph/lib/commons-beanutils-core-1.8.0.jar,/usr/lib/giraph/lib/hive-cli-0.10.0.jar,/usr/lib/giraph/lib/libfb303-0.9.0.jar,/usr/lib/giraph/lib/swift-service-0.13.1.jar,/usr/lib/giraph/lib/commons-cli-1.2.jar,/usr/lib/giraph/lib/hive-exec-0.11.0.jar,/usr/lib/giraph/lib/libthrift-0.9.0.jar,/usr/lib/giraph/lib/typetools-0.2.1.jar,/usr/lib/giraph/lib/commons-codec-1.8.jar,/usr/lib/giraph/lib/hive-io-exp-core-0.26.jar,/usr/lib/giraph/lib/log4j-1.2.17.jar,/usr/lib/giraph/lib/units-0.91.jar,/usr/lib/giraph/lib/commons-compress-1.4.1.jar,/usr/lib/giraph/lib/hive-metastore-0.11.0.jar,/usr/lib/giraph/lib/metrics-core-2.2.0.jar,/usr/lib/giraph/lib/validation-api-1.1.0.Final.jar,/usr/lib/giraph/lib/commons-configuration-1.6.jar,/usr/lib/giraph/lib/hive-pdk-0.10.0.jar,/usr/lib/giraph/lib/metrics-core-3.0.0.jar,/usr/lib/giraph/lib/velocity-1.7.jar,/usr/lib/giraph/lib/commons-dbcp-1.4.jar,/usr/lib/giraph/lib/hive-service-0.10.0.jar,/usr/lib/giraph/lib/neethi-3.0.1.jar,/usr/lib/giraph/lib/woodstox-core-asl-4.1.1.jar,/usr/lib/giraph/lib/commons-digester-1.8.jar,/usr/lib/giraph/lib/httpclient-4.1.2.jar,/usr/lib/giraph/lib/netty-3.6.2.Final.jar,/usr/lib/giraph/lib/wsdl4j-1.6.2.jar,/usr/lib/giraph/lib/commons-io-2.1.jar,/usr/lib/giraph/lib/httpcore-4.1.2.jar,/usr/lib/giraph/lib/netty-all-4.0.14.Final.jar,/usr/lib/giraph/lib/xmlschema-core-2.0.1.jar,/usr/lib/giraph/lib/commons-lang-2.6.jar,/usr/lib/giraph/lib/jackson-annotations-2.1.4.jar,/usr/lib/giraph/lib/nifty-client-0.13.1.jar,/usr/lib/giraph/lib/xz-1.0.jar,/usr/lib/giraph/lib/commons-lang3-3.1.jar,/usr/lib/giraph/lib/jackson-core-2.1.2.jar,/usr/lib/giraph/lib/nifty-core-0.13.1.jar,/usr/lib/giraph/lib/yjp-controller-api-redist-11.0.10.jar,/usr/lib/giraph/lib/commons-pool-1.5.4.jar,/usr/lib/giraph/lib/jackson-core-asl-1.9.2.jar,/usr/lib/giraph/lib/paranamer-2.5.2.jar,/usr/lib/giraph/lib/zookeeper-3.4.5.jar,/usr/lib/giraph/lib/concurrent-1.3.4.jar,/usr/lib/giraph/lib/jackson-databind-2.1.2.jar,/usr/lib/giraph/lib/protobuf-java-2.5.0.jar,/usr/lib/giraph/lib/configuration-0.91.jar,/usr/lib/giraph/lib/jackson-datatype-json-org-2.1.2.jar,/usr/lib/giraph/lib/reflectasm-1.07.jar,resources/giraph-examples-1.1.0.jar'
+        env['GIRAPH_HOME'] = giraph_home
+        env['HADOOP_CLASSPATH'] = "{ex}:{home}/*:{libdir}/*".format(
+            ex=giraph_examples,
+            home=giraph_home,
+            libdir=giraph_libdir)
+        env['LIB_JARS'] = ','.join(j for j in giraph_jars)
 
-
-    hookenv.status_set('active', 'ready')
     set_state('giraph.installed')
+    report_status()
+    # set app version string for juju status output
+    giraph_version = get_package_version('giraph') or 'unknown'
+    hookenv.application_version_set(giraph_version)

--- a/bigtop-packages/src/charm/giraph/layer-giraph/tests/01-basic-deployment.py
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/tests/01-basic-deployment.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import amulet
+
+
+class TestDeploy(unittest.TestCase):
+    """
+    Trivial deployment test for Giraph.
+    """
+    @classmethod
+    def setUpClass(cls):
+        cls.d = amulet.Deployment(series='xenial')
+        cls.d.add('giraph', 'cs:xenial/giraph')
+        cls.d.setup(timeout=900)
+        cls.d.sentry.wait(timeout=1800)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bigtop-packages/src/charm/giraph/layer-giraph/tests/01-giraph-test.py
+++ b/bigtop-packages/src/charm/giraph/layer-giraph/tests/01-giraph-test.py
@@ -26,20 +26,18 @@ class TestDeploy(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.d = amulet.Deployment(series='xenial')
-        cls.d.add('giraph', '/home/juju/workspace/charms/builds/giraph')
-        cls.d.add('client', 'cs:xenial/hadoop-client')
+        cls.d.add('giraph', 'cs:xenial/giraph')
         cls.d.add('resourcemanager', 'cs:xenial/hadoop-resourcemanager')
         cls.d.add('namenode', 'cs:xenial/hadoop-namenode')
         cls.d.add('slave', 'cs:xenial/hadoop-slave')
         cls.d.add('plugin', 'cs:xenial/hadoop-plugin')
 
-        cls.d.relate('plugin:hadoop-plugin', 'client:hadoop')
+        cls.d.relate('plugin:hadoop-plugin', 'giraph:hadoop')
         cls.d.relate('plugin:namenode', 'namenode:namenode')
         cls.d.relate('plugin:resourcemanager', 'resourcemanager:resourcemanager')
         cls.d.relate('slave:namenode', 'namenode:datanode')
         cls.d.relate('slave:resourcemanager', 'resourcemanager:nodemanager')
         cls.d.relate('namenode:namenode', 'resourcemanager:namenode')
-        cls.d.relate('giraph:mahout', 'client:mahout')
 
         cls.d.setup(timeout=3600)
         cls.d.sentry.wait_for_messages({"giraph": "ready"}, timeout=3600)
@@ -52,9 +50,9 @@ class TestDeploy(unittest.TestCase):
         uuid = self.giraph.run_action('smoke-test')
         result = self.d.action_fetch(uuid, full_output=True)
         print(result)
-        #action status=completed on success
+        # action status=completed on success
         if (result['status'] != "completed"):
-          self.fail('Giraph smoke-test failed: %s' % result)
+            self.fail('Giraph smoke-test failed: %s' % result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
What should have started as an open issue has turned into a full-blown PR.  Forgive me :)

I've been questioning whether the giraph charm should be subordinate to something like `hadoop-client`. Other subordinates (like `mahout`) could alter the `HADOOP_CLASSPATH` in `/etc/environment` and break giraph.  Also, scaling `hadoop-client` would scale all subordinates as well, which may not be desirable.

I think it makes more sense to offer giraph as a standalone charm that communicates directly with the cluster (via `hadoop-plugin`) versus indirectly (via `hadoop-client`).  This PR converts giraph to a standalone charm -- which is really quite trivial -- but I added a couple noteworthy refactors for fun:

- simplify the logic for adding jars to /etc/environment
- make the smoke test idempotent and a bit more maintainable, and save the output

Let me know what you think!